### PR TITLE
Update README to reflect proper usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip3 install -r requirements.txt
 ```
 ## Run
 ```sh
-python scrape.py output.json
+python -m classutil output.json
 ```
 
 The options are configurable, run with `--help` for more options.


### PR DESCRIPTION
Running `scrape.py` doesn't work, the cli is in `__main__.py`, and thus need to be invoked through the module.